### PR TITLE
Fix: Filter ignored packages

### DIFF
--- a/src/utils/AdbWrapper.js
+++ b/src/utils/AdbWrapper.js
@@ -202,7 +202,10 @@ export default class AdbWrapper {
         description: fields[2] || "",
         installed: installed.includes(fields[0]),
       };
-    });
+    })
+      .filter((item) => {
+        return item.installed || (!!item.version && !item.name?.includes(" "));
+      });
 
     return packages;
   }

--- a/src/utils/AdbWrapper.js
+++ b/src/utils/AdbWrapper.js
@@ -172,7 +172,7 @@ export default class AdbWrapper {
 
     await this.updataPackages();
     output = await this.adb.subprocess.spawnAndWait([
-      "/opt/bin/opkg",
+      this.wtfos.bin.opkg,
       "list",
     ]);
 


### PR DESCRIPTION
Fix: 
If "`Repo`=`All`" is selected **and** the package-architecture is not found in `opkg.conf` an invalid entry is displayed.

![image](https://user-images.githubusercontent.com/3527662/170352048-dcdd8756-ffeb-4c54-84bb-dbe13159efaa.png)

