### PR TITLE
Add Chroma Key option to OSD Overlay

### DIFF
--- a/src/features/osd-overlay/Config.jsx
+++ b/src/features/osd-overlay/Config.jsx
@@ -1,0 +1,80 @@
+import React from "react";
+import PropTypes from "prop-types";
+import {
+  Trans, useTranslation,
+} from "react-i18next";
+
+import {
+  FormGroup,
+  FormControlLabel,
+  FormHelperText,
+  Checkbox,
+  Paper,
+  Typography,
+  Stack,
+} from "@mui/material";
+
+import SettingsIcon from "@mui/icons-material/Settings";
+
+export default function Config(props) {
+  const {
+    config,
+    onChange,
+  } = props;
+
+  const { t } = useTranslation("osdOverlay");
+
+  const onChromaKeyChange = React.useCallback((event) => {
+    onChange({
+      ...config,
+      chromaKey: event.target.checked,
+    });
+  }, [config, onChange]);
+
+  return (
+    <Paper
+      elevation={0}
+      sx={{
+        pl: 2,
+        pr: 2,
+      }}
+    >
+      <Stack
+        alignItems="center"
+        direction="row"
+        justifyContent="center"
+        spacing={0.5}
+        sx={{ mt: 2 }}
+      >
+        <SettingsIcon />
+
+        <Typography variant="body1">
+          {t("configTitle")}
+        </Typography>
+      </Stack>
+
+      <Stack
+        sx={{ mb: 2 }}
+      >
+        <FormGroup>
+          <FormControlLabel
+            control={<Checkbox checked={config.chromaKey}  />}
+            label={t("configChromaKey")}
+            onChange={onChromaKeyChange}
+          />
+
+          <FormHelperText>
+            <Trans i18nKey="osdOverlay:configChromaKeyHelp">
+              <span style={{ color: "#FF00FF" }} />
+            </Trans>
+          </FormHelperText>
+        </FormGroup>
+      </Stack>
+    </Paper>
+  );
+}
+
+Config.propTypes = {
+  config: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  onChange: PropTypes.func.isRequired,
+};

--- a/src/features/osd-overlay/DebugStats.jsx
+++ b/src/features/osd-overlay/DebugStats.jsx
@@ -17,7 +17,7 @@ import {
   Typography,
 } from "@mui/material";
 
-import SettingsIcon from "@mui/icons-material/Settings";
+import ScienceIcon from "@mui/icons-material/Science";
 
 export default function DebugStats(props) {
   const { t } = useTranslation("osdOverlay");
@@ -91,7 +91,7 @@ export default function DebugStats(props) {
                 spacing={0.5}
                 sx={{ p: 1 }}
               >
-                <SettingsIcon />
+                <ScienceIcon />
 
                 <Typography variant="body1">
                   {t("debugStatsTitle")}

--- a/src/features/osd-overlay/OsdOverlay.jsx
+++ b/src/features/osd-overlay/OsdOverlay.jsx
@@ -12,12 +12,11 @@ import { useTranslation } from "react-i18next";
 import Header from "../navigation/Header";
 import DefaultTextLink from "../styledLink/Default";
 
+import Config from "./Config";
 import DebugStats from "./DebugStats";
 import FileDrop, { useFileDropState } from "./FileDrop";
 
 import VideoWorkerManager from "../../osd-overlay/manager";
-import VideoWorkerShared from "../../osd-overlay/shared";
-
 
 const videoManager = new VideoWorkerManager();
 
@@ -49,6 +48,8 @@ export default function OsdOverlay() {
     queuedForDecode: null,
     queuedForEncode: null,
   });
+
+  const [config, setConfig] = React.useState({ chromaKey: false });
 
   const [inProgress, setInProgress] = React.useState(false);
   const [startedOnce, setStartedOnce] = React.useState(false);
@@ -155,13 +156,14 @@ export default function OsdOverlay() {
     setStartedOnce(true);
 
     videoManager.start({
-      type: VideoWorkerShared.MessageType.START,
+      chromaKey: config.chromaKey,
       fontFiles: fontFiles,
       osdFile: osdFile,
-      videoFile: videoFile,
       outHandle: handle,
+      videoFile: videoFile,
     });
   }, [
+    config,
     fontFiles,
     osdFile,
     setInProgress,
@@ -265,6 +267,11 @@ export default function OsdOverlay() {
                 variant={
                   inProgress && progressValue >= 99 ? "indeterminate" : "determinate"
                 }
+              />
+
+              <Config
+                config={config}
+                onChange={setConfig}
               />
 
               <DebugStats

--- a/src/osd-overlay/manager.ts
+++ b/src/osd-overlay/manager.ts
@@ -83,6 +83,7 @@ export default class VideoWorkerManager {
     osdFile: File,
     outHandle: FileSystemFileHandle
     videoFile: File,
+    chromaKey: boolean
   }) {
     this.postMessage({
       type: VideoWorkerShared.MessageType.START,

--- a/src/osd-overlay/shared.ts
+++ b/src/osd-overlay/shared.ts
@@ -39,10 +39,12 @@ namespace VideoWorkerShared {
 
   export interface StartMessage {
     type: MessageType.START;
+
+    chromaKey: boolean;
     fontFiles: FontPackFiles,
     osdFile: File;
-    videoFile: File;
     outHandle: FileSystemFileHandle;
+    videoFile: File;
   }
 
   export type Message =

--- a/src/translations/en/osdOverlay.json
+++ b/src/translations/en/osdOverlay.json
@@ -1,4 +1,7 @@
 {
+  "configTitle": "Settings",
+  "configChromaKey": "Chroma Key",
+  "configChromaKeyHelp": "Renders OSD above a <0>magenta background</0> rather than the actual video. The DVR video is still used (currently) for timing purposes, though.",
   "debugStatsExpectedFrames": "Expected Frames",
   "debugStatsFramesDecoded": "Frames Decoded",
   "debugStatsFramesDecodedMissing": "Frames Decoded (Missing)",


### PR DESCRIPTION
Few folks have been asking for this! 🚀 

Just skips blitting the video frame basically and does a magenta background instead. 

Still runs off the DVR video for timing, etc., etc. Could improve this later to generate from the OSD files directly.

![image](https://user-images.githubusercontent.com/622619/227749350-f5f4aa14-d270-4c59-8f63-985a359f1218.png)
