### PR TITLE
Explicitly don't cache proxied http requests; fixes #328

### DIFF
--- a/src/utils/Proxy.js
+++ b/src/utils/Proxy.js
@@ -82,15 +82,19 @@ export default class Proxy {
      * with the original url anyway.
      */
     const httpsUrl = url.replace(/^http:\/\//, "https://");
+    const requestOptions = {
+      method,
+      cache: "no-store",
+    };
 
     let response = null;
     try {
-      const request = new Request(httpsUrl, { method });
+      const request = new Request(httpsUrl, requestOptions);
       response = await fetch(request);
       return response;
     } catch(e) {
       const corsProxyUrl = this.corsProxy + url;
-      const corsRequest = new Request(corsProxyUrl, { method });
+      const corsRequest = new Request(corsProxyUrl, requestOptions);
       try {
         response = await fetch(corsRequest);
         return response;


### PR DESCRIPTION
Fix for #328 

Browser caching is gone:

<img width="1210" alt="Screenshot 2023-04-26 at 23 02 50" src="https://user-images.githubusercontent.com/194052/234712957-dc46c3d6-f7dd-4ffa-b1f8-3ce05f32664d.png">
