### PR TITLE
Faster version check in Step 1 of rooting

### DIFF
--- a/src/utils/exploit/Exploit.js
+++ b/src/utils/exploit/Exploit.js
@@ -412,7 +412,7 @@ export default class Exploit {
     base64Encoded = base64Encoded.replaceAll("/", "_");
     base64Encoded = base64Encoded.replaceAll("+", "-");
 
-    const baseUrl = `${this.corsProxy}https://drone-hacks.com/get/otawm150/7645436e-a439-11eb-bcbc-0242ac130002`;
+    const baseUrl = `${this.corsProxy}https://api.fpv.tools/ota`;
     const url = `${baseUrl}/${base64Encoded}`;
 
     let res = null;

--- a/src/utils/exploit/Exploit.js
+++ b/src/utils/exploit/Exploit.js
@@ -180,7 +180,7 @@ export default class Exploit {
     return object;
   }
 
-  async talk(command, wait, timeout = 5000) {
+  async talk(command, wait, timeout = 5000, careful = true) {
     const pack = new Pack();
 
     pack.senderType = 10;
@@ -224,13 +224,15 @@ export default class Exploit {
      * It is needed because otherwise step 4 (maybe others) will do
      * strange things.
      */
-    await this.closePort();
-    await this.sleep(1000);
-
-    const ports = await navigator.serial.getPorts();
-    const port = ports[0];
-    await this.openPort(port);
-    await this.sleep(1000);
+    if(careful) {
+      await this.closePort();
+      await this.sleep(1000);
+  
+      const ports = await navigator.serial.getPorts();
+      const port = ports[0];
+      await this.openPort(port);
+      await this.sleep(1000);
+    }
 
     const object = await this.sendAndReceive(pack.cmdId, packedBuffer, wait, timeout, validator);
     return object;
@@ -299,7 +301,7 @@ export default class Exploit {
           }
 
           command.data = Buffer.from("0100" + chunk.toString(16).padStart(2, "0") + "0000e8030000", "hex");
-          const response = await this.talk(command, true);
+          const response = await this.talk(command, true, 5000, false);
 
           left = response.data[6];
           if(left === undefined) {


### PR DESCRIPTION
There's no good reason to do the port shuffle when downloading the .cfg.sig.

I added an option to talk() to skip it, thus speeding up the version check a bazillion times.