### PR TITLE
Fix wtfos uninstall in edge cases where cmdline is busy

### DIFF
--- a/src/utils/AdbWrapper.js
+++ b/src/utils/AdbWrapper.js
@@ -862,12 +862,16 @@ export default class AdbWrapper {
     output = await this.executeCommand("rm -r /opt");
     output = await this.executeCommand("mount -o ro,remount /");
 
-    output = await this.executeCommand(`rm -r ${this.wtfos.path}`);
-    if(output.exitCode !== 0) {
-      statusCallback("ERROR: Failed cleaning up");
-      output.stdout.split("\n").forEach((line) => statusCallback(line));
-      return;
-    }
+    let retries = 0;
+    do {
+      if(retries > 20) {
+        statusCallback("ERROR: Failed cleaning up");
+        output.stdout.split("\n").forEach((line) => statusCallback(line));
+        return;
+      }
+      output = await this.executeCommand(`rm -r ${this.wtfos.path}`);
+      retries++;
+    } while (output.exitCode !== 0);
 
     const hasAdbRemoval = await this.fileExists(this.wtfos.bin.adbRemoval);
     if(hasAdbRemoval) {


### PR DESCRIPTION
Added retry mechanism to removal of wtfos blackbox dir during uninstall to avoid issues with cmdline being busy.