### PR TITLE
OSD overlay fix for osd elements outside video

### DIFF
--- a/src/osd-overlay/worker.ts
+++ b/src/osd-overlay/worker.ts
@@ -114,11 +114,13 @@ export class VideoWorker {
   }
 
   modifyFrame(frame: ImageBitmap, frameIndex: number): ImageBitmap {
-    const osdCanvas = this.osdCanvas!;
-    const osdCtx = this.osdCtx!;
     const frameCanvas = this.frameCanvas!;
     const frameCtx = this.frameCtx!;
+    const osdCanvas = this.osdCanvas!;
+    const osdCtx = this.osdCtx!;
 
+    frameCtx.fillStyle = this.chromaKey ? this.chromaKeyColor : 'black';
+    frameCtx.fillRect(0, 0, frameCanvas.width, frameCanvas.height);
     osdCtx.clearRect(0, 0, osdCanvas.width, osdCanvas.height);
 
     if (!this.chromaKey) {
@@ -129,9 +131,6 @@ export class VideoWorker {
         frameXOffset = 0;
       }
       frameCtx.drawImage(frame, frameXOffset, 0);
-    } else {
-      frameCtx.fillStyle = this.chromaKeyColor;
-      frameCtx.fillRect(0, 0, frameCanvas.width, frameCanvas.height);
     }
 
     if (this.lastOsdIndex < this.osdReader!.frames.length - 1) {


### PR DESCRIPTION
Fixes an issue in the OSD overlay feature. OSD elements that are positioned outside of the video area would not be cleared and artifacts from the last OSD frame would still be visible.

Example before the change:
![Screenshot_2](https://github.com/fpv-wtf/wtfos-configurator/assets/16101005/1f7239eb-a59f-435a-9869-29184de15f74)

After the change:
![Screenshot_3](https://github.com/fpv-wtf/wtfos-configurator/assets/16101005/8d1c8e60-e6db-4154-bac3-c2601a9a4a8e)
