### PR TITLE
Support modified video files for OSD overlay

### DIFF
--- a/src/osd-overlay/mp4/parsers.ts
+++ b/src/osd-overlay/mp4/parsers.ts
@@ -34,6 +34,7 @@ import {
   UrlBox,
   UrnBox,
   VmhdBox,
+  CttsBox,
 } from "./types";
 
 export async function parseBox(stream: FileStreamReader): Promise<Box> {
@@ -88,6 +89,7 @@ export async function parseBox(stream: FileStreamReader): Promise<Box> {
     trak: TrakBoxParser,
     udta: UdtaBoxParser,
     vmhd: VmhdBoxParser,
+    ctts: CttsBoxParser,
   };
 
   let parser: BoxParser<Box>;
@@ -457,6 +459,7 @@ class StblBoxParser extends SimpleBoxParser<StblBox> {
       stss: childBoxes.stss![0] as StssBox,
       stsz: childBoxes.stsz![0] as StszBox,
       stts: childBoxes.stts![0] as SttsBox,
+      ctts: childBoxes.ctts ? childBoxes.ctts![0] as CttsBox : undefined
     };
   }
 }
@@ -758,6 +761,30 @@ class VmhdBoxParser extends FullBoxParser<VmhdBox> {
       type: "vmhd",
       graphicsMode,
       opColor,
+    };
+  }
+}
+
+class CttsBoxParser extends FullBoxParser<CttsBox> {
+  async parseBox(
+    header: BoxHeader,
+    fullBoxHeader: FullBoxHeader
+  ): Promise<CttsBox> {
+    const sampleCount = await this.stream.getNextUint32();
+    const sampleCounts = [];
+    const sampleOffsets = [];
+
+    for (let i = 0; i < sampleCount; i++) {
+      sampleCounts.push(await this.stream.getNextUint32());
+      sampleOffsets.push(await this.stream.getNextUint32());
+    }
+
+    return {
+      header,
+      fullBoxHeader,
+      type: "ctts",
+      sampleCounts,
+      sampleOffsets,
     };
   }
 }

--- a/src/osd-overlay/mp4/types.ts
+++ b/src/osd-overlay/mp4/types.ts
@@ -33,6 +33,7 @@ export type BoxType =
   | "url "
   | "urn "
   | "vmhd"
+  | "ctts"
   | UnknownBoxType;
 
 export type ContainerBox =
@@ -68,6 +69,7 @@ export type Box =
   | UrlBox
   | UrnBox
   | VmhdBox
+  | CttsBox
   | UnknownBox;
 
 export interface BoxHeader {
@@ -124,6 +126,7 @@ export interface StblBox extends BaseBox<"stbl"> {
   stss: StssBox;
   stsz: StszBox;
   stts: SttsBox;
+  ctts?: CttsBox;
 }
 
 export interface UdtaBox extends BaseBox<"udta"> {}
@@ -261,6 +264,11 @@ export interface HdlrBox extends BaseFullBox<"hdlr"> {
 export interface VmhdBox extends BaseFullBox<"vmhd"> {
   graphicsMode: number;
   opColor: number[];
+}
+
+export interface CttsBox extends BaseFullBox<"ctts"> {
+  sampleCounts: number[];
+  sampleOffsets: number[];
 }
 
 export interface UrlBox extends BaseFullBox<"url "> {

--- a/src/osd-overlay/processor.ts
+++ b/src/osd-overlay/processor.ts
@@ -313,31 +313,31 @@ export class Processor {
   }
 
   private reorderFrames(lastSampleIndex: number) {
-    const orderedFrames = []
+    const orderedFrames = [];
     const ctts = this.inMp4!.moov!.trak[0].mdia.minf.stbl.ctts;
 
     if (!ctts) {
       // No ctts box found: no reordering needed
       for (let i = 0; i < Object.keys(this.decodedFrames).length; i++) {
-        orderedFrames.push(this.decodedFrames[lastSampleIndex + i])
+        orderedFrames.push(this.decodedFrames[lastSampleIndex + i]);
       }
     } else {
       // Reorder frames according to ctts table
       const sampleDelta = this.inMp4!.moov!.trak[0].mdia.minf.stbl.stts.entries[0].sampleDelta;
-      const initialOffset = ctts.sampleOffsets[0] / sampleDelta
+      const initialOffset = ctts.sampleOffsets[0] / sampleDelta;
 
       for (let i = 0; i < Object.keys(this.decodedFrames).length; i++) {
-        const frameNumber = lastSampleIndex + i
+        const frameNumber = lastSampleIndex + i;
 
         let j = 0;
         let frame = 0;
         while (frameNumber >= frame) {
-          j++
-          frame = ctts.sampleCounts.slice(0, j).reduce((acc, e) => acc + e, 0)
+          j++;
+          frame = ctts.sampleCounts.slice(0, j).reduce((acc, e) => acc + e, 0);
         }
 
         const newPosition = i + ctts.sampleOffsets[j - 1] / sampleDelta - initialOffset;
-        orderedFrames[newPosition] = Object.assign({}, this.decodedFrames[lastSampleIndex + i], {index: lastSampleIndex + newPosition})
+        orderedFrames[newPosition] = Object.assign({}, this.decodedFrames[lastSampleIndex + i], {index: lastSampleIndex + newPosition});
       }
     }
 

--- a/src/translations/el/osdOverlay.json
+++ b/src/translations/el/osdOverlay.json
@@ -22,7 +22,7 @@
   "fileDropVideo": "Video",
   "noteConfigLink": "Configure this in the Package Manager.",
   "noteHeader": "OSD recording is an opt-in feature on the goggle side.",
-  "noteWarning": "Any video files used must come directly from the goggles, with no modifications.",
+  "noteWarning": "The video file must either come directly from the goggles, or have only modifications that don't change the length of the video. Altering the aspect ratio, stabilization, etc are supported.",
   "processing": "Processing...",
   "start": "Start"
 }

--- a/src/translations/en/osdOverlay.json
+++ b/src/translations/en/osdOverlay.json
@@ -22,7 +22,7 @@
   "fileDropVideo": "Video",
   "noteConfigLink": "Configure this in the Package Manager.",
   "noteHeader": "OSD recording is an opt-in feature on the goggle side.",
-  "noteWarning": "Any video files used must come directly from the goggles, with no modifications.",
+  "noteWarning": "The video file must either come directly from the goggles, or have only modifications that don't change the length of the video. Altering the aspect ratio, stabilization, etc are supported.",
   "processing": "Processing...",
   "start": "Start"
 }

--- a/src/translations/nl/osdOverlay.json
+++ b/src/translations/nl/osdOverlay.json
@@ -22,7 +22,7 @@
   "fileDropVideo": "Video",
   "noteConfigLink": "Configure this in the Package Manager.",
   "noteHeader": "OSD recording is an opt-in feature on the goggle side.",
-  "noteWarning": "Any video files used must come directly from the goggles, with no modifications.",
+  "noteWarning": "The video file must either come directly from the goggles, or have only modifications that don't change the length of the video. Altering the aspect ratio, stabilization, etc are supported.",
   "processing": "Processing...",
   "start": "Start"
 }

--- a/src/translations/sk/osdOverlay.json
+++ b/src/translations/sk/osdOverlay.json
@@ -22,7 +22,7 @@
   "fileDropVideo": "Video",
   "noteConfigLink": "Configure this in the Package Manager.",
   "noteHeader": "OSD recording is an opt-in feature on the goggle side.",
-  "noteWarning": "Any video files used must come directly from the goggles, with no modifications.",
+  "noteWarning": "The video file must either come directly from the goggles, or have only modifications that don't change the length of the video. Altering the aspect ratio, stabilization, etc are supported.",
   "processing": "Processing...",
   "start": "Start"
 }

--- a/src/translations/sv/osdOverlay.json
+++ b/src/translations/sv/osdOverlay.json
@@ -22,7 +22,7 @@
   "fileDropVideo": "Video",
   "noteConfigLink": "Configure this in the Package Manager.",
   "noteHeader": "OSD recording is an opt-in feature on the goggle side.",
-  "noteWarning": "Any video files used must come directly from the goggles, with no modifications.",
+  "noteWarning": "The video file must either come directly from the goggles, or have only modifications that don't change the length of the video. Altering the aspect ratio, stabilization, etc are supported.",
   "processing": "Processing...",
   "start": "Start"
 }

--- a/src/translations/uk/osdOverlay.json
+++ b/src/translations/uk/osdOverlay.json
@@ -22,7 +22,7 @@
   "fileDropVideo": "Video",
   "noteConfigLink": "Configure this in the Package Manager.",
   "noteHeader": "OSD recording is an opt-in feature on the goggle side.",
-  "noteWarning": "Any video files used must come directly from the goggles, with no modifications.",
+  "noteWarning": "The video file must either come directly from the goggles, or have only modifications that don't change the length of the video. Altering the aspect ratio, stabilization, etc are supported.",
   "processing": "Processing...",
   "start": "Start"
 }

--- a/src/translations/vi/osdOverlay.json
+++ b/src/translations/vi/osdOverlay.json
@@ -22,7 +22,7 @@
   "fileDropVideo": "Video",
   "noteConfigLink": "Configure this in the Package Manager.",
   "noteHeader": "OSD recording is an opt-in feature on the goggle side.",
-  "noteWarning": "Any video files used must come directly from the goggles, with no modifications.",
+  "noteWarning": "The video file must either come directly from the goggles, or have only modifications that don't change the length of the video. Altering the aspect ratio, stabilization, etc are supported.",
   "processing": "Processing...",
   "start": "Start"
 }

--- a/src/translations/zh-TW/osdOverlay.json
+++ b/src/translations/zh-TW/osdOverlay.json
@@ -22,7 +22,7 @@
   "fileDropVideo": "Video",
   "noteConfigLink": "Configure this in the Package Manager.",
   "noteHeader": "OSD recording is an opt-in feature on the goggle side.",
-  "noteWarning": "Any video files used must come directly from the goggles, with no modifications.",
+  "noteWarning": "The video file must either come directly from the goggles, or have only modifications that don't change the length of the video. Altering the aspect ratio, stabilization, etc are supported.",
   "processing": "Processing...",
   "start": "Start"
 }


### PR DESCRIPTION
Currently the OSD overlay feature only supports video files that come straight from the goggles. This PR adds support for modifications as long as they don't change the video length.

Technical: video files straight from the goggles have all frames in the correct order. Tools like gyroflow or superviou save frames in a different order that they are supposed to be shown. The correct order is described in the optional ctts box in the mp4 spec.

An example of footage that has the aspect ratio altered with [superviou](https://github.com/meekaah/SuperViou):
![image](https://github.com/fpv-wtf/wtfos-configurator/assets/16101005/bbd2c689-5b5b-44be-90b7-9fc642d5a511)
