### PR TITLE
OSD Overlay create a MP4 clip much longer than the original

### DIFF
--- a/src/osd-overlay/mp4/index.ts
+++ b/src/osd-overlay/mp4/index.ts
@@ -254,7 +254,7 @@ export class MP4Writer {
       },
       alternateGroup: 0,
       creationTime: nowMp4Time,
-      duration: this.sampleCount * 60,
+      duration: Math.floor((this.sampleCount * 1000) / this.frameRate),
       width: this.displaySize!.width,
       height: this.displaySize!.height,
       layer: 0,

--- a/src/osd-overlay/processor.ts
+++ b/src/osd-overlay/processor.ts
@@ -268,7 +268,7 @@ export class Processor {
       // Processed files may need reordering of the frames described in the ctts box.
       const orderedFrames = this.reorderFrames(lastSampleIndex);
 
-      // Modify and enque frames for encoding.
+      // Modify and enqueue frames for encoding.
       this.encodedFrames = [];
       for (const [index, entry] of orderedFrames.entries()) {
         if (!entry.image) {


### PR DESCRIPTION
This PR fixes #392 OSD Overlay create a MP4 clip much longer than the original