### PR TITLE
Fix font filename when font variant is missing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wtfos-configurator",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "homepage": "https://fpv.wtf",
   "private": true,
   "dependencies": {

--- a/src/osd-overlay/fonts.ts
+++ b/src/osd-overlay/fonts.ts
@@ -35,7 +35,9 @@ export class Font {
       if (file && file.size > 0) {
         return [file.name, await file.arrayBuffer()];
       } else {
-        const font_filename = `font_${reader.header.config.fontVariant.toLowerCase()}${isHd ? "_hd" : ""}.png`;
+        const font_variant = reader.header.config.fontVariant.toLowerCase();
+        const font_name = font_variant.length !== 0 ? `font_${font_variant}` : "font";
+        const font_filename = `${font_name}${isHd ? "_hd" : ""}.png`;
         return ["font_filename", await fetch(`https://raw.githubusercontent.com/fpv-wtf/msp-osd/main/fonts/${font_filename}`).then((response) => response.arrayBuffer())];
       }
     })(file);


### PR DESCRIPTION
Fix invalid font name when the font variant is missing on the OSD file. 
It was creating a font_.png file name which was invalid.