### PR TITLE
feat: add report issue button for packages

### DIFF
--- a/src/features/package/Package.jsx
+++ b/src/features/package/Package.jsx
@@ -19,6 +19,7 @@ import Form from "@rjsf/mui";
 import Alert from "@mui/material/Alert";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
+import BugReportIcon from "@mui/icons-material/BugReport";
 import DeleteIcon from "@mui/icons-material/Delete";
 import DownloadIcon from "@mui/icons-material/Download";
 import Grid from "@mui/material/Grid";
@@ -231,6 +232,31 @@ export default function Package({ adb }) {
                       >
                         <InfoIcon
                           color="success"
+                          data-key={packageName}
+                          sx={{ fontSize: 40 }}
+                        />
+                      </IconButton>
+                    </Link>}
+
+                  {details.homepage && details.homepage.includes("github.com") &&
+                    <Link
+                      href={`${details.homepage}/issues/new`}
+                      sx={{
+                        whiteSpace: "nowrap",
+                        textDecoration: "none",
+                      }}
+                      target="_blank"
+                    >
+                      <IconButton
+                        aria-label={t("reportIssue")}
+                        sx={{
+                          width: 65,
+                          height: 65,
+                        }}
+                        title={t("reportIssue")}
+                      >
+                        <BugReportIcon
+                          color="warning"
                           data-key={packageName}
                           sx={{ fontSize: 40 }}
                         />

--- a/src/features/packages/Packages.jsx
+++ b/src/features/packages/Packages.jsx
@@ -12,6 +12,7 @@ import {
 import { useTranslation } from "react-i18next";
 
 import Box from "@mui/material/Box";
+import BugReportIcon from "@mui/icons-material/BugReport";
 import DeleteIcon from "@mui/icons-material/Delete";
 import DownloadIcon from "@mui/icons-material/Download";
 import FormControl from "@mui/material/FormControl";
@@ -257,6 +258,31 @@ export default function Packages({ adb }) {
               >
                 <InfoIcon
                   color="success"
+                  data-key={item.name}
+                  sx={{ fontSize: 40 }}
+                />
+              </IconButton>
+            </Link>}
+
+          {item.details.homepage && item.details.homepage.includes("github.com") &&
+            <Link
+              href={`${item.details.homepage}/issues/new`}
+              sx={{
+                whiteSpace: "nowrap",
+                textDecoration: "none",
+              }}
+              target="_blank"
+            >
+              <IconButton
+                aria-label={t("reportIssue")}
+                sx={{
+                  width: 65,
+                  height: 65,
+                }}
+                title={t("reportIssue")}
+              >
+                <BugReportIcon
+                  color="warning"
                   data-key={item.name}
                   sx={{ fontSize: 40 }}
                 />

--- a/src/translations/en/package.json
+++ b/src/translations/en/package.json
@@ -3,6 +3,7 @@
   "submit": "Save settings",
   "loading": "Loading package details...",
   "visitProjectPage": "Visit project page",
+  "reportIssue": "Report issue on GitHub",
   "maintainer": "Maintainer: {{name}}",
   "remove": "Remove",
   "install": "Install",

--- a/src/translations/en/packages.json
+++ b/src/translations/en/packages.json
@@ -17,6 +17,7 @@
   "description": "Description",
   "matchCount": "Found {{count}} packages",
   "visitProjectPage": "Visit project page",
+  "reportIssue": "Report issue on GitHub",
   "labelCategory": "Category",
   "labelCategoryAllExceptSystem": "All (except system)",
   "labelCategoryAll": "All",


### PR DESCRIPTION
## Summary

Adds a "Report Issue on GitHub" button next to the existing project info button for each package, so users can quickly file bugs on the correct package repository instead of on wtfos-configurator.

### Changes

- **Package detail view** (`Package.jsx`) — new bug report icon button appears when the package homepage is a GitHub URL, linking to `{homepage}/issues/new`
- **Package list view** (`Packages.jsx`) — same button added to the list table
- **Translations** — added `reportIssue` key to both `en/package.json` and `en/packages.json`

The button only renders when `details.homepage` contains `github.com`, so non-GitHub packages are unaffected.

Closes #344

## Test plan

- [ ] Navigate to a package with a GitHub homepage — verify the bug report icon (warning color) appears next to the info icon
- [ ] Click the bug report button — should open `{homepage}/issues/new` in a new tab
- [ ] Check a package without a GitHub homepage — the button should not appear
- [ ] Verify the button appears in both the package list view and the package detail view