### PR TITLE
feat: add continue button after root/install/uninstall/update

### DIFF
--- a/src/features/root/Root.jsx
+++ b/src/features/root/Root.jsx
@@ -45,7 +45,10 @@ import {
   success,
   selectAttempted,
   selectRooting,
+  selectSuccess,
 } from "./rootSlice";
+
+import SuccessContinue from "../setup/SuccessContinue";
 
 import {
   appendToLog,
@@ -87,6 +90,7 @@ export default function Root() {
   const attempted = useSelector(selectAttempted);
   const hasAdb = useSelector(selectHasAdb);
   const rooting = useSelector(selectRooting);
+  const rootSuccess = useSelector(selectSuccess);
 
   const donationState = useSelector(selectDonationState);
 
@@ -537,6 +541,9 @@ export default function Root() {
           </Button>
 
           <Log />
+
+          {rootSuccess &&
+            <SuccessContinue message={t("rootSuccess")} />}
         </>
       </Stack>
 

--- a/src/features/setup/Install.jsx
+++ b/src/features/setup/Install.jsx
@@ -24,7 +24,10 @@ import {
   rebooting,
   selectHasOpkgBinary,
   selectNiceName,
+  selectRebooting,
 } from "../device/deviceSlice";
+
+import SuccessContinue from "./SuccessContinue";
 
 import {
   installWTFOS,
@@ -39,6 +42,7 @@ export default function Install({ adb }) {
 
   const hasOpkgBinary = useSelector(selectHasOpkgBinary);
   const isProcessing = useSelector(selectProcessing);
+  const isRebooting = useSelector(selectRebooting);
   const deviceName = useSelector(selectNiceName);
   const healthchecksPassed = useSelector(selectPassed);
 
@@ -90,6 +94,9 @@ export default function Install({ adb }) {
       </Button>
 
       <Log />
+
+      {isRebooting &&
+        <SuccessContinue message={t("installSuccess")} />}
     </Stack>
   );
 }

--- a/src/features/setup/Remove.jsx
+++ b/src/features/setup/Remove.jsx
@@ -23,7 +23,10 @@ import {
   rebooting,
   selectHasOpkgBinary,
   selectNiceName,
+  selectRebooting,
 } from "../device/deviceSlice";
+
+import SuccessContinue from "./SuccessContinue";
 
 import {
   removeWTFOS,
@@ -36,6 +39,7 @@ export default function Remove({ adb }) {
 
   const hasOpkgBinary = useSelector(selectHasOpkgBinary);
   const isProcessing = useSelector(selectProcessing);
+  const isRebooting = useSelector(selectRebooting);
   const deviceName = useSelector(selectNiceName);
 
   const onClick = useCallback(async (device) => {
@@ -75,6 +79,9 @@ export default function Remove({ adb }) {
       </Button>
 
       <Log />
+
+      {isRebooting &&
+        <SuccessContinue message={t("removeSuccess")} />}
     </Stack>
   );
 }

--- a/src/features/setup/SuccessContinue.jsx
+++ b/src/features/setup/SuccessContinue.jsx
@@ -1,0 +1,30 @@
+import PropTypes from "prop-types";
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+
+import Alert from "@mui/material/Alert";
+import Button from "@mui/material/Button";
+import Stack from "@mui/material/Stack";
+
+export default function SuccessContinue({ message }) {
+  const { t } = useTranslation("setup");
+  const navigate = useNavigate();
+
+  return (
+    <Stack spacing={2}>
+      <Alert severity="success">
+        {message}
+      </Alert>
+
+      <Button
+        onClick={() => navigate("/")}
+        variant="contained"
+      >
+        {t("continue")}
+      </Button>
+    </Stack>
+  );
+}
+
+SuccessContinue.propTypes = { message: PropTypes.string.isRequired };

--- a/src/features/setup/Update.jsx
+++ b/src/features/setup/Update.jsx
@@ -18,6 +18,7 @@ import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 
 import Spinner from "../loading/Spinner";
+import SuccessContinue from "./SuccessContinue";
 
 import {
   setLog,
@@ -82,9 +83,7 @@ export default function Update({ adb }) {
       <PackageManagementError />
 
       {update.ran && update.success &&
-        <Alert severity="success">
-          {t("updateSuccess")}
-        </Alert>}
+        <SuccessContinue message={t("updateSuccess")} />}
 
       {upgradable.length > 0 &&
         <Button

--- a/src/translations/en/root.json
+++ b/src/translations/en/root.json
@@ -33,5 +33,6 @@
   "unlockFailed": "Unlock failed, please power-cycle your device and try again.",
   "patchFailed": "Patch failed, please power-cycle your device and try again.",
   "unsupportedFirmware": "The firmware on your device is too new. You may be able to downgrade to V01.01.0606 in DIY mode with DJI FPV Assistant 2 depending on the exact version installed. Please <a href='https://github.com/fpv-wtf/wtfos/wiki/Supported-firmware-versions#fpv-goggles-v2'>see the wiki</a> for more details.",
-  "signingServerUnreachable": "The signing server could not be reached. It might be down or your ISP might be blocking it."
+  "signingServerUnreachable": "The signing server could not be reached. It might be down or your ISP might be blocking it.",
+  "rootSuccess": "Your device has been successfully rooted!"
 }

--- a/src/translations/en/setup.json
+++ b/src/translations/en/setup.json
@@ -21,5 +21,8 @@
   "latest": "Latest Version",
   "updateSuccess": "Updates installed successfully!",
   "updateFailed": "Failed installing updates!",
-  "fetchUpgradableFailed": "Failed fetching upgradable packages!"
+  "fetchUpgradableFailed": "Failed fetching upgradable packages!",
+  "continue": "Continue",
+  "installSuccess": "WTFOS installed successfully! Your device is rebooting.",
+  "removeSuccess": "WTFOS removed successfully! Your device is rebooting."
 }


### PR DESCRIPTION
## Summary

Adds a reusable **SuccessContinue** component that displays a success alert (text via props) and a "Continue" button that navigates the user back to the home page. This is integrated into all four operation pages as discussed in the issue:

- **Root** — shown after rooting completes successfully
- **Install wtfOS** — shown after install triggers a reboot
- **Uninstall wtfOS** — shown after removal triggers a reboot
- **Update wtfOS** — replaces the existing bare success alert with the component (includes the Continue button)

### Implementation notes

- Same component used everywhere per @stylesuxx's guidance
- Component accepts a `message` prop for the success text
- Based on `develop` branch as requested
- Translation keys added to `en/setup.json` and `en/root.json`

Closes #337

## Test plan

- [ ] Root a device — after success, verify the green alert and "Continue" button appear
- [ ] Click "Continue" — should navigate to `/`
- [ ] Install wtfOS — after reboot, verify the continue button appears
- [ ] Remove wtfOS — after reboot, verify the continue button appears
- [ ] Update wtfOS — after success, verify the existing alert is replaced by one with a continue button